### PR TITLE
Add support for TagOwners and Tests in ACL configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
-test: 
-	go test -i $(TEST) || exit 1                                                   
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+test:
+	go test -i $(TEST) || exit 1
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+testacc:
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -173,15 +173,23 @@ func (c *Client) DNSNameservers(ctx context.Context) ([]string, error) {
 }
 
 type DomainACL struct {
-	ACLs   []DomainACLEntry    `json:"acls"`
-	Groups map[string][]string `json:"groups,omitempty"`
-	Hosts  map[string]string   `json:"hosts,omitempty"`
+	ACLs      []DomainACLEntry    `json:"acls"`
+	Groups    map[string][]string `json:"groups,omitempty"`
+	Hosts     map[string]string   `json:"hosts,omitempty"`
+	TagOwners map[string][]string `json:"tagowners,omitempty"`
+	Tests     []DomainACLTest     `json:"tests,omitempty"`
 }
 
 type DomainACLEntry struct {
 	Action string   `json:"action"`
 	Ports  []string `json:"ports"`
 	Users  []string `json:"users"`
+}
+
+type DomainACLTest struct {
+	User  string   `json:"user"`
+	Allow []string `json:"allow"`
+	Deny  []string `json:"deny"`
 }
 
 // ACL retrieves the ACL that is currently set for the given domain.

--- a/internal/tailscale/client_test.go
+++ b/internal/tailscale/client_test.go
@@ -1,0 +1,91 @@
+package tailscale_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDomainACL_Unmarshal(t *testing.T) {
+	acl := `
+	{
+		"acls": [
+			{
+				"action": "accept",
+				"users": ["*"],
+				"ports": ["*:*"]
+			}
+		],
+		"tagowners": {
+			"tag:example": [
+				"group:example"
+			]
+		},
+		"groups": {
+			"group:example": [
+				"user1@example.com",
+				"user2@example.com"
+			]
+		},
+		"hosts": {
+			"example-host-1": "100.100.100.100",
+			"example-host-2": "100.100.101.100/24"
+		},
+		"tests": [
+			{
+				"user": "user1@example.com",
+				"allow": ["example-host-1:22", "example-host-2:80"],
+				"deny": ["exapmle-host-2:100"]
+			},
+			{
+				"user": "user2@example.com",
+				"allow": ["100.60.3.4:22"]
+			}
+		]
+	}`
+
+	var actual tailscale.DomainACL
+	if err := json.Unmarshal([]byte(acl), &actual); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := tailscale.DomainACL{
+		ACLs: []tailscale.DomainACLEntry{
+			{
+				Action: "accept",
+				Ports:  []string{"*:*"},
+				Users:  []string{"*"},
+			},
+		},
+		TagOwners: map[string][]string{
+			"tag:example": {"group:example"},
+		},
+		Hosts: map[string]string{
+			"example-host-1": "100.100.100.100",
+			"example-host-2": "100.100.101.100/24",
+		},
+		Groups: map[string][]string{
+			"group:example": {
+				"user1@example.com",
+				"user2@example.com",
+			},
+		},
+		Tests: []tailscale.DomainACLTest{
+			{
+				User:  "user1@example.com",
+				Allow: []string{"example-host-1:22", "example-host-2:80"},
+				Deny:  []string{"exapmle-host-2:100"},
+			},
+			{
+				User:  "user2@example.com",
+				Allow: []string{"100.60.3.4:22"},
+			},
+		},
+	}
+
+	if !cmp.Equal(expected, actual) {
+		t.Fatal("unmarshalled ACL does not match expected value")
+	}
+}

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -16,6 +16,32 @@ const testACL = `
 					"users": ["*"],
 					"ports": ["*:*"]
 				}
+			],
+			"tagowners": {
+				"tag:example": [
+					"group:example"
+				]
+			},
+			"groups": {
+				"group:example": [
+					"user1@example.com",
+					"user2@example.com"
+				]
+			},
+			"hosts": {
+				"example-host-1": "100.100.100.100",
+				"example-host-2": "100.100.101.100/24"
+			},
+			"tests": [
+				{
+					"user": "user1@example.com",
+					"allow": ["example-host-1:22", "example-host-2:80"],
+					"deny": ["exapmle-host-2:100"]
+				},
+				{
+					"user": "user2@example.com",
+					"allow": ["100.60.3.4:22"]
+				}
 			]
 		}
 		EOF


### PR DESCRIPTION
Fixes #11

Adds support for both the `Tests` and `TagOwners` fields in ACL configuration. These were previously not included
in the request to the ACL endpoint. Updates the acceptance test to include a full ACL and adds a test to ensure
JSON marshalling of the ACL works as expected.

Signed-off-by: David Bond <davidsbond93@gmail.com>