### PR TITLE
Change references to "domains" to "tailnets".

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Do not keep your api key in HCL for production environments, use Terraform envir
 ```terraform
 provider "tailscale" {
   api_key = "my_api_key"
-  domain = "example.com"
+  tailnet = "example.com"
 }
 ```
 
@@ -26,4 +26,4 @@ provider "tailscale" {
 ### Required
 
 - **api_key** (String) API key to authenticate with the Tailscale API
-- **domain** (String) Tailscale domain to manage resources for
+- **tailnet** (String) Tailscale tailnet to manage resources for

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "tailscale" {
   api_key = "my-api-key"
-  domain = "my-domain"
+  tailnet = "my-tailnet"
 }
 
 resource "tailscale_acl" "sample_acl" {

--- a/internal/tailscale/client_test.go
+++ b/internal/tailscale/client_test.go
@@ -46,13 +46,13 @@ func TestDomainACL_Unmarshal(t *testing.T) {
 		]
 	}`
 
-	var actual tailscale.DomainACL
+	var actual tailscale.ACL
 	if err := json.Unmarshal([]byte(acl), &actual); err != nil {
 		t.Fatal(err)
 	}
 
-	expected := tailscale.DomainACL{
-		ACLs: []tailscale.DomainACLEntry{
+	expected := tailscale.ACL{
+		ACLs: []tailscale.ACLEntry{
 			{
 				Action: "accept",
 				Ports:  []string{"*:*"},
@@ -72,7 +72,7 @@ func TestDomainACL_Unmarshal(t *testing.T) {
 				"user2@example.com",
 			},
 		},
-		Tests: []tailscale.DomainACLTest{
+		Tests: []tailscale.ACLTest{
 			{
 				User:  "user1@example.com",
 				Allow: []string{"example-host-1:22", "example-host-2:80"},

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -22,9 +22,9 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_API_KEY", nil),
 				Required:    true,
 			},
-			"domain": {
+			"tailnet": {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_DOMAIN", nil),
+				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_TAILNET", nil),
 				Required:    true,
 			},
 		},
@@ -39,9 +39,9 @@ func Provider() *schema.Provider {
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	apiKey := d.Get("api_key").(string)
-	domain := d.Get("domain").(string)
+	tailnet := d.Get("tailnet").(string)
 
-	client := tailscale.NewClient(apiKey, domain)
+	client := tailscale.NewClient(apiKey, tailnet)
 	return client, nil
 }
 

--- a/tailscale/provider_test.go
+++ b/tailscale/provider_test.go
@@ -32,8 +32,8 @@ func testProviderPreCheck(t *testing.T) {
 	if err := os.Getenv("TAILSCALE_API_KEY"); err == "" {
 		t.Fatal("TAILSCALE_API_KEY must be set for acceptance tests")
 	}
-	if err := os.Getenv("TAILSCALE_DOMAIN"); err == "" {
-		t.Fatal("TAILSCALE_DOMAIN must be set for acceptance tests")
+	if err := os.Getenv("TAILSCALE_TAILNET"); err == "" {
+		t.Fatal("TAILSCALE_TAILNET must be set for acceptance tests")
 	}
 }
 

--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -30,7 +30,7 @@ func resourceACL() *schema.Resource {
 }
 
 func validateACL(i interface{}, _ cty.Path) diag.Diagnostics {
-	var acl tailscale.DomainACL
+	var acl tailscale.ACL
 	if err := json.Unmarshal([]byte(i.(string)), &acl); err != nil {
 		return diagnosticsError(err, "Invalid ACL")
 	}
@@ -38,8 +38,8 @@ func validateACL(i interface{}, _ cty.Path) diag.Diagnostics {
 }
 
 func suppressACLDiff(_, old, new string, _ *schema.ResourceData) bool {
-	var oldACL tailscale.DomainACL
-	var newACL tailscale.DomainACL
+	var oldACL tailscale.ACL
+	var newACL tailscale.ACL
 
 	if err := json.Unmarshal([]byte(old), &oldACL); err != nil {
 		return false
@@ -81,7 +81,7 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	client := m.(*tailscale.Client)
 	aclStr := d.Get("acl").(string)
 
-	var acl tailscale.DomainACL
+	var acl tailscale.ACL
 	if err := json.Unmarshal([]byte(aclStr), &acl); err != nil {
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
@@ -102,7 +102,7 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		return nil
 	}
 
-	var acl tailscale.DomainACL
+	var acl tailscale.ACL
 	if err := json.Unmarshal([]byte(aclStr), &acl); err != nil {
 		return diagnosticsError(err, "Failed to unmarshal ACL")
 	}
@@ -117,8 +117,8 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 func resourceACLDelete(ctx context.Context, _ *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*tailscale.Client)
 
-	acl := tailscale.DomainACL{
-		ACLs: []tailscale.DomainACLEntry{
+	acl := tailscale.ACL{
+		ACLs: []tailscale.ACLEntry{
 			{
 				Action: "accept",
 				Users:  []string{"*"},


### PR DESCRIPTION
The Tailscale API's lingo has changed, instead of calling them domains they're now
referred to as tailnets. The provider has been updated so that the work tailnet
is now expected instead.