### PR TITLE
Add terraform resource for device_subnet_routes

### DIFF
--- a/docs/resources/device_subnet_routes.md
+++ b/docs/resources/device_subnet_routes.md
@@ -1,0 +1,32 @@
+---
+page_title: "device_subnet_routes Resource - terraform-provider-tailscale"
+subcategory: ""
+description: |-
+The device_subnet_routes resource allows you to configure subnet routes for your Tailscale devices.
+---
+
+# Resource `tailscale_device_subnet_routes`
+
+The device_subnet_routes resource allows you to configure subnet routes for your Tailscale devices. See the
+[Tailscale subnets documentation](https://tailscale.com/kb/1019/subnets) for more information.
+
+## Example Usage
+
+```terraform
+resource "tailscale_device_subnet_routes" "sample_routes" {
+  device_id = "my-device"
+  routes = [
+    "10.0.1.0/24", 
+    "1.2.0.0/16", 
+    "2.0.0.0/24",
+  ]
+}
+```
+
+## Argument Reference
+
+- `device_id` - (Required) The device to change enabled subroutes for.
+- `routes` - (Required) The subnet routes that are enabled to be routed by a device. Routes can be enabled without a 
+  device advertising them (e.g. for preauth).
+
+

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -247,3 +247,44 @@ func (c *Client) SetDNSPreferences(ctx context.Context, preferences DNSPreferenc
 
 	return c.performRequest(req, nil)
 }
+
+type (
+	DeviceRoutes struct {
+		Advertised []string `json:"advertisedRoutes"`
+		Enabled    []string `json:"enabledRoutes"`
+	}
+)
+
+// SetDeviceSubnetRoutes sets which subnet routes are enabled to be routed by a device by replacing the existing list
+// of subnet routes with the supplied routes. Routes can be enabled without a device advertising them (e.g. for preauth).
+func (c *Client) SetDeviceSubnetRoutes(ctx context.Context, deviceID string, routes []string) error {
+	const uriFmt = " /api/v2/device/%s/routes"
+
+	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), map[string][]string{
+		"routes": routes,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
+}
+
+// DeviceSubnetRoutes Retrieves the list of subnet routes that a device is advertising, as well as those that are
+// enabled for it. Enabled routes are not necessarily advertised (e.g. for pre-enabling), and likewise, advertised
+// routes are not necessarily enabled.
+func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*DeviceRoutes, error) {
+	const uriFmt = " /api/v2/device/%s/routes"
+
+	req, err := c.buildRequest(ctx, http.MethodGet, fmt.Sprintf(uriFmt, deviceID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp DeviceRoutes
+	if err = c.performRequest(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -29,10 +29,11 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"tailscale_acl":              resourceACL(),
-			"tailscale_dns_nameservers":  resourceDNSNameservers(),
-			"tailscale_dns_preferences":  resourceDNSPreferences(),
-			"tailscale_dns_search_paths": resourceDNSSearchPaths(),
+			"tailscale_acl":                  resourceACL(),
+			"tailscale_dns_nameservers":      resourceDNSNameservers(),
+			"tailscale_dns_preferences":      resourceDNSPreferences(),
+			"tailscale_dns_search_paths":     resourceDNSSearchPaths(),
+			"tailscale_device_subnet_routes": resourceDeviceSubnetRoutes(),
 		},
 	}
 }

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -1,0 +1,95 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDeviceSubnetRoutes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceDeviceSubnetRoutesRead,
+		CreateContext: resourceDeviceSubnetRoutesCreate,
+		UpdateContext: resourceDeviceSubnetRoutesUpdate,
+		DeleteContext: resourceDeviceSubnetRoutesDelete,
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The device to set subnet routes for",
+			},
+			"routes": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required:    true,
+				Description: "The subnet routes that are enabled to be routed by a device",
+			},
+		},
+	}
+}
+
+func resourceDeviceSubnetRoutesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	routes, err := client.DeviceSubnetRoutes(ctx, deviceID)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch dns nameservers")
+	}
+
+	if err = d.Set("routes", routes.Enabled); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+	routes := d.Get("routes").([]interface{})
+
+	subnetRoutes := make([]string, len(routes))
+	for i, route := range routes {
+		subnetRoutes[i] = route.(string)
+	}
+
+	if err := client.SetDeviceSubnetRoutes(ctx, deviceID, subnetRoutes); err != nil {
+		return diagnosticsError(err, "Failed to set device subnet routes")
+	}
+
+	d.SetId(createUUID())
+	return nil
+}
+
+func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+	routes := d.Get("routes").([]interface{})
+
+	subnetRoutes := make([]string, len(routes))
+	for i, route := range routes {
+		subnetRoutes[i] = route.(string)
+	}
+
+	if err := client.SetDeviceSubnetRoutes(ctx, deviceID, subnetRoutes); err != nil {
+		return diagnosticsError(err, "Failed to set device subnet routes")
+	}
+
+	return nil
+}
+
+func resourceDeviceSubnetRoutesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	if err := client.SetDeviceSubnetRoutes(ctx, deviceID, []string{}); err != nil {
+		return diagnosticsError(err, "Failed to set device subnet routes")
+	}
+
+	return nil
+}

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -1,0 +1,28 @@
+package tailscale_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const testDeviceSubnetRoutes = `
+	resource "tailscale_device_subnet_routes" "test_subnet_routes" {
+		device_id = "my-device"
+		routes = [
+			"10.0.1.0/24", 
+			"1.2.0.0/16", 
+			"2.0.0.0/24",
+		]
+	}`
+
+func TestProvider_TailscaleDeviceSubnetRoutes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testProviderPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			testResourceCreated("tailscale_device_subnet_routes.test_subnet_routes", testDeviceSubnetRoutes),
+			testResourceDestroyed("tailscale_device_subnet_routes.test_subnet_routes", testDeviceSubnetRoutes),
+		},
+	})
+}


### PR DESCRIPTION
Adds a `device_subnet_routes` resource to the provider, allowing users to specify which
subnet routes are enbaled to be routed by a device.