### PR TITLE
Add descriptions to all current resources

### DIFF
--- a/tailscale/resource_acl.go
+++ b/tailscale/resource_acl.go
@@ -13,6 +13,7 @@ import (
 
 func resourceACL() *schema.Resource {
 	return &schema.Resource{
+		Description:   "The acl resource allows you to configure a Tailscale ACL. See https://tailscale.com/kb/1018/acls for more information.",
 		ReadContext:   resourceACLRead,
 		CreateContext: resourceACLCreate,
 		UpdateContext: resourceACLUpdate,

--- a/tailscale/resource_dns_nameservers.go
+++ b/tailscale/resource_dns_nameservers.go
@@ -10,6 +10,7 @@ import (
 
 func resourceDNSNameservers() *schema.Resource {
 	return &schema.Resource{
+		Description:   "The dns_nameservers resource allows you to configure DNS nameservers for your Tailscale network. See https://tailscale.com/kb/1054/dns for more information.",
 		ReadContext:   resourceDNSNameserversRead,
 		CreateContext: resourceDNSNameserversCreate,
 		UpdateContext: resourceDNSNameserversUpdate,

--- a/tailscale/resource_dns_preferences.go
+++ b/tailscale/resource_dns_preferences.go
@@ -10,6 +10,7 @@ import (
 
 func resourceDNSPreferences() *schema.Resource {
 	return &schema.Resource{
+		Description:   "The dns_preferences resource allows you to configure DNS preferences for your Tailscale network. See https://tailscale.com/kb/1054/dns for more information.",
 		ReadContext:   resourceDNSPreferencesRead,
 		CreateContext: resourceDNSPreferencesCreate,
 		UpdateContext: resourceDNSPreferencesUpdate,

--- a/tailscale/resource_dns_search_paths.go
+++ b/tailscale/resource_dns_search_paths.go
@@ -10,6 +10,7 @@ import (
 
 func resourceDNSSearchPaths() *schema.Resource {
 	return &schema.Resource{
+		Description:   "The dns_nameservers resource allows you to configure DNS nameservers for your Tailscale network. See https://tailscale.com/kb/1054/dns for more information.",
 		ReadContext:   resourceDNSSearchPathsRead,
 		UpdateContext: resourceDNSSearchPathsUpdate,
 		DeleteContext: resourceDNSSearchPathsDelete,


### PR DESCRIPTION
Realised each of the schema.Resource types provides a description field, so have copied in text
to match the documentation.