### PR TITLE
Add device data source

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -1,0 +1,29 @@
+---
+page_title: "device Data Source - terraform-provider-tailscale"
+subcategory: ""
+description: |-
+The device data source describes a single device in a tailnet.
+---
+
+# Data Source `device`
+
+The device data source describes a single device in a tailnet.
+
+## Example Usage
+
+```terraform
+data "tailscale_device" "sample_device" {
+  name = "user1-device.example.com"
+}
+
+```
+
+## Argument Reference
+
+- `name` - (Required) The name of the tailnet device to obtain the attributes of.
+
+## Attributes Reference
+
+The following attributes are exported.
+
+- `id` - The unique identifier for the device

--- a/docs/resources/device_subnet_routes.md
+++ b/docs/resources/device_subnet_routes.md
@@ -13,11 +13,15 @@ The device_subnet_routes resource allows you to configure subnet routes for your
 ## Example Usage
 
 ```terraform
+data "tailscale_device" "sample_device" {
+  name = "device.example.com"
+}
+
 resource "tailscale_device_subnet_routes" "sample_routes" {
-  device_id = "my-device"
+  device_id = tailscale_device.sample_device.id,
   routes = [
-    "10.0.1.0/24", 
-    "1.2.0.0/16", 
+    "10.0.1.0/24",
+    "1.2.0.0/16",
     "2.0.0.0/24",
   ]
 }

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -288,3 +288,42 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 
 	return &resp, nil
 }
+
+type (
+	Device struct {
+		Addresses                 []string  `json:"addresses"`
+		ClientVersion             string    `json:"clientVersion"`
+		Os                        string    `json:"os"`
+		Name                      string    `json:"name"`
+		Created                   time.Time `json:"created"`
+		LastSeen                  string    `json:"lastSeen"`
+		Hostname                  string    `json:"hostname"`
+		Machinekey                string    `json:"machineKey"`
+		NodeKey                   string    `json:"nodeKey"`
+		ID                        string    `json:"id"`
+		User                      string    `json:"user"`
+		Expires                   time.Time `json:"expires"`
+		KeyExpiryDisabled         bool      `json:"keyExpiryDisabled"`
+		Authorized                bool      `json:"authorized"`
+		IsExternal                bool      `json:"isExternal"`
+		UpdateAvailable           bool      `json:"updateAvailable"`
+		BlocksIncomingConnections bool      `json:"blocksIncomingConnections"`
+	}
+)
+
+// Devices lists the devices in a tailnet.
+func (c *Client) Devices(ctx context.Context) ([]Device, error) {
+	const uriFmt = "/api/v2/tailnet/%s/devices"
+
+	req, err := c.buildRequest(ctx, http.MethodGet, fmt.Sprintf(uriFmt, c.tailnet), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(map[string][]Device)
+	if err = c.performRequest(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp["devices"], nil
+}

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -1,0 +1,50 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDevice() *schema.Resource {
+	return &schema.Resource{
+		Description: "The device data source describes a single device in a tailnet",
+		ReadContext: dataSourceDeviceRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the device",
+			},
+		},
+	}
+}
+
+func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	name := d.Get("name").(string)
+
+	devices, err := client.Devices(ctx)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch devices")
+	}
+
+	var selected *tailscale.Device
+	for _, device := range devices {
+		if device.Name != name {
+			continue
+		}
+
+		selected = &device
+		break
+	}
+
+	if selected == nil {
+		return diag.Errorf("Could not find device with name %s", name)
+	}
+
+	d.SetId(selected.ID)
+	return nil
+}

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -35,6 +35,9 @@ func Provider() *schema.Provider {
 			"tailscale_dns_search_paths":     resourceDNSSearchPaths(),
 			"tailscale_device_subnet_routes": resourceDeviceSubnetRoutes(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"tailscale_device": dataSourceDevice(),
+		},
 	}
 }
 

--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -10,6 +10,7 @@ import (
 
 func resourceDeviceSubnetRoutes() *schema.Resource {
 	return &schema.Resource{
+		Description:   "The device_subnet_routes resource allows you to configure subnet routes for your Tailscale devices. See https://tailscale.com/kb/1019/subnets for more information.",
 		ReadContext:   resourceDeviceSubnetRoutesRead,
 		CreateContext: resourceDeviceSubnetRoutesCreate,
 		UpdateContext: resourceDeviceSubnetRoutesUpdate,

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -7,8 +7,12 @@ import (
 )
 
 const testDeviceSubnetRoutes = `
+	data "tailscale_device" "test_device" {
+		name = "device.example.com"
+	}
+	
 	resource "tailscale_device_subnet_routes" "test_subnet_routes" {
-		device_id = "my-device"
+		device_id = tailscale_device.test_device.id,
 		routes = [
 			"10.0.1.0/24", 
 			"1.2.0.0/16", 


### PR DESCRIPTION
In order to use resources like `tailscale_device_subnet_routes`, users will need to be able to provide
a device identifier. This commit adds the ability to obtain a device identifier using a new `tailscale_device`
data source, where a name is provided to obtain the device identifier, which can then be used by other
resources.

Signed-off-by: David Bond <davidsbond93@gmail.com>