### PR TITLE
Remove unused device fields

### DIFF
--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -291,23 +291,8 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 
 type (
 	Device struct {
-		Addresses                 []string  `json:"addresses"`
-		ClientVersion             string    `json:"clientVersion"`
-		Os                        string    `json:"os"`
-		Name                      string    `json:"name"`
-		Created                   time.Time `json:"created"`
-		LastSeen                  string    `json:"lastSeen"`
-		Hostname                  string    `json:"hostname"`
-		Machinekey                string    `json:"machineKey"`
-		NodeKey                   string    `json:"nodeKey"`
-		ID                        string    `json:"id"`
-		User                      string    `json:"user"`
-		Expires                   time.Time `json:"expires"`
-		KeyExpiryDisabled         bool      `json:"keyExpiryDisabled"`
-		Authorized                bool      `json:"authorized"`
-		IsExternal                bool      `json:"isExternal"`
-		UpdateAvailable           bool      `json:"updateAvailable"`
-		BlocksIncomingConnections bool      `json:"blocksIncomingConnections"`
+		Name string `json:"name"`
+		ID   string `json:"id"`
 	}
 )
 


### PR DESCRIPTION
This commit removes fields that are not directly used by the terraform provider from
the `Device` type.

This change is required to fix #24, as the API returns blank strings for dates, resulting in
errors unmarshalling the JSON response into a `Device` type. Since it's unlikely the provider
will ever need these dates, we can just remove them. The provider also only exposes the id
and name, so everything else can be removed for now too.

Signed-off-by: David Bond <davidsbond93@gmail.com>