### PR TITLE
Fix incorrect HCL in device subnet routes

### DIFF
--- a/docs/resources/device_subnet_routes.md
+++ b/docs/resources/device_subnet_routes.md
@@ -18,7 +18,7 @@ data "tailscale_device" "sample_device" {
 }
 
 resource "tailscale_device_subnet_routes" "sample_routes" {
-  device_id = tailscale_device.sample_device.id,
+  device_id = data.tailscale_device.sample_device.id,
   routes = [
     "10.0.1.0/24",
     "1.2.0.0/16",


### PR DESCRIPTION
The correct HCL should prefix the data field with `data.`.

Signed-off-by: David Bond <davidsbond93@gmail.com>
