### PR TITLE
Remove leading whitespace from path

### DIFF
--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -258,7 +258,7 @@ type (
 // SetDeviceSubnetRoutes sets which subnet routes are enabled to be routed by a device by replacing the existing list
 // of subnet routes with the supplied routes. Routes can be enabled without a device advertising them (e.g. for preauth).
 func (c *Client) SetDeviceSubnetRoutes(ctx context.Context, deviceID string, routes []string) error {
-	const uriFmt = " /api/v2/device/%s/routes"
+	const uriFmt = "/api/v2/device/%s/routes"
 
 	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), map[string][]string{
 		"routes": routes,


### PR DESCRIPTION
This commit removes a leading whitespace in the path when attempting to
set device subnet routes via the API. Due to the extra whitespace the
call was actually hitting the UI instead of than API with a POST request,
causing the issue with the invalid CSRF token.

Fixes #29

Signed-off-by: David Bond <davidsbond93@gmail.com>
