### PR TITLE
Remove whitespace in device subnet route uri

### DIFF
--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -274,7 +274,7 @@ func (c *Client) SetDeviceSubnetRoutes(ctx context.Context, deviceID string, rou
 // enabled for it. Enabled routes are not necessarily advertised (e.g. for pre-enabling), and likewise, advertised
 // routes are not necessarily enabled.
 func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*DeviceRoutes, error) {
-	const uriFmt = " /api/v2/device/%s/routes"
+	const uriFmt = "/api/v2/device/%s/routes"
 
 	req, err := c.buildRequest(ctx, http.MethodGet, fmt.Sprintf(uriFmt, deviceID), nil)
 	if err != nil {


### PR DESCRIPTION
This commit fixes #31 by removing whitespace that was left in front of the
uri path when calling the device subnet route endpoint.

Signed-off-by: David Bond <davidsbond93@gmail.com>