### PR TITLE
Update ACL examples to use jsonencode

### DIFF
--- a/docs/resources/acl.md
+++ b/docs/resources/acl.md
@@ -14,17 +14,15 @@ for more information.
 
 ```terraform
 resource "tailscale_acl" "sample_acl" {
-  acl = <<EOF
-  {
-    "acls": [
-        {
-            "action": "accept",
-            "users": ["*"],
-            "ports": ["*:*"]
-        }
-    ]
-  }
-EOF
+  acl = jsonencode({
+    acls : [
+      {
+        // Allow all users access to all ports.
+        action = "accept",
+        users  = ["*"],
+        ports  = ["*:*"],
+      }],
+  })
 }
 ```
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -13,17 +13,15 @@ provider "tailscale" {
 }
 
 resource "tailscale_acl" "sample_acl" {
-  acl = <<EOF
-  {
-    "acls": [
-        {
-            "action": "accept",
-            "users": ["*"],
-            "ports": ["*:*"]
-        }
-    ]
-  }
-EOF
+  acl = jsonencode({
+    acls : [
+      {
+        // Allow all users access to all ports.
+        action = "accept",
+        users  = ["*"],
+        ports  = ["*:*"],
+      }],
+  })
 }
 
 


### PR DESCRIPTION
This commit modifies the example/documentation for ACLs to use the `jsonencode` function
instead of heredocs.

Closes #36

Signed-off-by: David Bond <davidsbond93@gmail.com>