### PR TITLE
add 'addresses' field to device and devices resources

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -27,3 +27,4 @@ data "tailscale_device" "sample_device" {
 The following attributes are exported.
 
 - `id` - The unique identifier for the device
+- `addresses` - Tailscale IPs for the device

--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -29,3 +29,4 @@ The following attributes are exported.
 - `devices` - The list of devices returned from the Tailscale API. Each element contains the following:
   - `id` - The unique identifier of the device
   - `name` - The name of the device
+  - `addresses` - Tailscale IPs for the device

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -292,8 +292,9 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 
 type (
 	Device struct {
-		Name string `json:"name"`
-		ID   string `json:"id"`
+		Addresses []string `json:"addresses"`
+		Name      string   `json:"name"`
+		ID        string   `json:"id"`
 	}
 )
 

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -18,6 +18,14 @@ func dataSourceDevice() *schema.Resource {
 				Required:    true,
 				Description: "The name of the device",
 			},
+			"addresses": {
+				Type:        schema.TypeList,
+				Description: "The list of device's IPs",
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -46,5 +54,6 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	d.SetId(selected.ID)
+	d.Set("addresses", selected.Addresses)
 	return nil
 }

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -35,6 +35,14 @@ func dataSourceDevices() *schema.Resource {
 							Description: "The unique identifier of the device",
 							Computed:    true,
 						},
+						"addresses": {
+							Computed:    true,
+							Type:        schema.TypeList,
+							Description: "The list of device's IPs",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -58,8 +66,9 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interf
 		}
 
 		deviceMaps = append(deviceMaps, map[string]interface{}{
-			"name": device.Name,
-			"id":   device.ID,
+			"addresses": device.Addresses,
+			"name":      device.Name,
+			"id":        device.ID,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds  'addresses' to the `tailscale_device`and `tailscale_devices` resources for IP address lookups.