### PR TITLE
Implement device_authorization resource

### DIFF
--- a/docs/resources/device_authorization.md
+++ b/docs/resources/device_authorization.md
@@ -1,0 +1,34 @@
+---
+page_title: "device_authorization Resource - terraform-provider-tailscale"
+subcategory: ""
+description: |-
+The device_authorization resource allows you to review and approve new devices before they can join the tailnet.
+---
+
+# Resource `tailscale_device_authorization`
+
+The device_authorization resource is used to approve new devices before they can join the tailnet.
+See the [Tailscale device authorization documentation](https://tailscale.com/kb/1099/device-authorization) for more
+information.
+
+The Tailscale API currently only supports authorizing devices, but not rejecting/removing them. Once a device is
+authorized by this provider it cannot be modified again afterwards. Modifying or deleting the resource
+will not affect the device's authorization within the tailnet.
+
+## Example Usage
+
+```terraform
+data "tailscale_device" "sample_device" {
+  name = "device.example.com"
+}
+
+resource "tailscale_device_authorization" "sample_authorization" {
+  device_id = data.tailscale_device.sample_device.id,
+  authorized = true
+}
+```
+
+## Argument Reference
+
+- `device_id` - (Required) The device to authorize.
+- `authorized` - (Required) Indicates if the device is allowed to join the tailnet.

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -346,13 +346,12 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 	return &resp, nil
 }
 
-type (
-	Device struct {
-		Addresses []string `json:"addresses"`
-		Name      string   `json:"name"`
-		ID        string   `json:"id"`
-	}
-)
+type Device struct {
+	Addresses  []string `json:"addresses"`
+	Name       string   `json:"name"`
+	ID         string   `json:"id"`
+	Authorized bool     `json:"authorized"`
+}
 
 // Devices lists the devices in a tailnet.
 func (c *Client) Devices(ctx context.Context) ([]Device, error) {
@@ -369,4 +368,18 @@ func (c *Client) Devices(ctx context.Context) ([]Device, error) {
 	}
 
 	return resp["devices"], nil
+}
+
+// AuthorizeDevice marks the specified device identifier as authorized to join the tailnet.
+func (c *Client) AuthorizeDevice(ctx context.Context, deviceID string) error {
+	const uriFmt = "/api/v2/device/%s/authorized"
+
+	req, err := c.buildRequest(ctx, http.MethodPost, fmt.Sprintf(uriFmt, deviceID), map[string]bool{
+		"authorized": true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.performRequest(req, nil)
 }

--- a/internal/tailscale/client_test.go
+++ b/internal/tailscale/client_test.go
@@ -411,3 +411,20 @@ func TestClient_SetDNSSearchPaths(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
 	assert.EqualValues(t, paths, body["searchPaths"])
 }
+
+func TestClient_AuthorizeDevice(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	const deviceID = "test"
+
+	assert.NoError(t, client.AuthorizeDevice(context.Background(), deviceID))
+	assert.Equal(t, http.MethodPost, server.Method)
+	assert.Equal(t, "/api/v2/device/test/authorized", server.Path)
+
+	body := make(map[string]bool)
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &body))
+	assert.EqualValues(t, true, body["authorized"])
+}

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -35,6 +35,7 @@ func Provider() *schema.Provider {
 			"tailscale_dns_preferences":      resourceDNSPreferences(),
 			"tailscale_dns_search_paths":     resourceDNSSearchPaths(),
 			"tailscale_device_subnet_routes": resourceDeviceSubnetRoutes(),
+			"tailscale_device_authorization": resourceDeviceAuthorization(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"tailscale_device":  dataSourceDevice(),

--- a/tailscale/resource_device_authorization.go
+++ b/tailscale/resource_device_authorization.go
@@ -1,0 +1,117 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDeviceAuthorization() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The device_authorization resource is used to approve new devices before they can join the tailnet. See https://tailscale.com/kb/1099/device-authorization/ for more details.",
+		ReadContext:   resourceDeviceAuthorizationRead,
+		CreateContext: resourceDeviceAuthorizationCreate,
+		UpdateContext: resourceDeviceAuthorizationUpdate,
+		DeleteContext: resourceDeviceAuthorizationDelete,
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The device to set as authorized",
+			},
+			"authorized": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether or not the device is authorized",
+			},
+		},
+	}
+}
+
+func resourceDeviceAuthorizationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	devices, err := client.Devices(ctx)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch devices")
+	}
+
+	var selected *tailscale.Device
+	for _, device := range devices {
+		if device.ID != deviceID {
+			continue
+		}
+
+		selected = &device
+		break
+	}
+
+	if selected == nil {
+		return diag.Errorf("Could not find device with id %s", deviceID)
+	}
+
+	d.SetId(selected.ID)
+	d.Set("authorized", selected.Authorized)
+	return nil
+}
+
+func resourceDeviceAuthorizationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+	authorized := d.Get("authorized").(bool)
+
+	if authorized {
+		if err := client.AuthorizeDevice(ctx, deviceID); err != nil {
+			return diagnosticsError(err, "Failed to authorize device")
+		}
+	}
+
+	d.SetId(deviceID)
+	return nil
+}
+
+func resourceDeviceAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	devices, err := client.Devices(ctx)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch devices")
+	}
+
+	var selected *tailscale.Device
+	for _, device := range devices {
+		if device.ID != deviceID {
+			continue
+		}
+
+		selected = &device
+		break
+	}
+
+	if selected == nil {
+		return diag.Errorf("Could not find device with id %s", deviceID)
+	}
+
+	// Currently, the Tailscale API only supports authorizing a device, but not un-authorizing one. So if the device
+	// data from the API states it is authorized then we can't do anything else here.
+	if selected.Authorized {
+		d.Set("authorized", true)
+		return nil
+	}
+
+	if err = client.AuthorizeDevice(ctx, deviceID); err != nil {
+		return diagnosticsError(err, "Failed to authorize device")
+	}
+
+	d.Set("authorized", true)
+	return nil
+}
+
+func resourceDeviceAuthorizationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Since authorization cannot be removed at this point, deleting the resource will do nothing.
+	return nil
+}

--- a/tailscale/resource_device_authorization_test.go
+++ b/tailscale/resource_device_authorization_test.go
@@ -1,0 +1,28 @@
+package tailscale_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const testDeviceAuthorization = `
+	data "tailscale_device" "test_device" {
+		name = "device.example.com"
+	}
+	
+	resource "tailscale_device_authorization" "test_authorization" {
+		device_id = data.tailscale_device.test_device.id,
+		authorized = true
+	}`
+
+func TestProvider_TailscaleDeviceAuthorization(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testProviderPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			testResourceCreated("tailscale_device_authorization.test_authorization", testDeviceAuthorization),
+			testResourceDestroyed("tailscale_device_authorization.test_authorization", testDeviceAuthorization),
+		},
+	})
+}


### PR DESCRIPTION
This commit introduces the `tailscale_device_authorization` resource. This resource allows you to approve devices to join your tailnet via the terraform provider. Device authorization is explained in more detail within [Tailscale's documentation](https://tailscale.com/kb/1099/device-authorization/).

One caveat to this resource is that the Tailscale API [does not support removing authorization](https://github.com/tailscale/tailscale/blob/main/api.md#post-body-1) from a device. So an update from true to false or removal of the resource will not affect the authorized status of the device.

Closes #42

Signed-off-by: David Bond <davidsbond93@gmail.com>