### PR TITLE
Add 'user' field to device and devices data sources

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -27,4 +27,5 @@ data "tailscale_device" "sample_device" {
 The following attributes are exported.
 
 - `id` - The unique identifier for the device
+- `user` - The user associated with the device
 - `addresses` - Tailscale IPs for the device

--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -29,4 +29,5 @@ The following attributes are exported.
 - `devices` - The list of devices returned from the Tailscale API. Each element contains the following:
   - `id` - The unique identifier of the device
   - `name` - The name of the device
+  - `user` - The user associated with the device
   - `addresses` - Tailscale IPs for the device

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -351,6 +351,7 @@ type Device struct {
 	Name       string   `json:"name"`
 	ID         string   `json:"id"`
 	Authorized bool     `json:"authorized"`
+	User       string   `json:"user"`
 }
 
 // Devices lists the devices in a tailnet.

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -18,6 +18,11 @@ func dataSourceDevice() *schema.Resource {
 				Required:    true,
 				Description: "The name of the device",
 			},
+			"user": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The user associated with the device",
+			},
 			"addresses": {
 				Type:        schema.TypeList,
 				Description: "The list of device's IPs",
@@ -54,6 +59,7 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	d.SetId(selected.ID)
+	d.Set("user", selected.User)
 	d.Set("addresses", selected.Addresses)
 	return nil
 }

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -30,6 +30,11 @@ func dataSourceDevices() *schema.Resource {
 							Description: "The name of the device",
 							Computed:    true,
 						},
+						"user": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The user associated with the device",
+						},
 						"id": {
 							Type:        schema.TypeString,
 							Description: "The unique identifier of the device",
@@ -68,6 +73,7 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interf
 		deviceMaps = append(deviceMaps, map[string]interface{}{
 			"addresses": device.Addresses,
 			"name":      device.Name,
+			"user":      device.User,
 			"id":        device.ID,
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a user attribute to the `tailscale_device` and `tailscale_devices` data sources, so we can access the user associated with a device.

**Which issue this PR fixes**: 
Fixes #48 

**Special notes for your reviewer**:
I haven't run the acceptance tests as I don't have a test tailscale account to test against.