### PR TITLE
Make acceptance tests generally runnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,19 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /go/pkg/mod
+            /root/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run tests
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,34 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /go/pkg/mod
+            /root/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v3
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+type ProviderOption func(p *schema.Provider)
+
 // Provider returns the *schema.Provider instance that implements the terraform provider.
-func Provider() *schema.Provider {
-	return &schema.Provider{
+func Provider(options ...ProviderOption) *schema.Provider {
+	provider := &schema.Provider{
 		ConfigureContextFunc: providerConfigure,
 		Schema: map[string]*schema.Schema{
 			"api_key": {
@@ -42,6 +44,12 @@ func Provider() *schema.Provider {
 			"tailscale_devices": dataSourceDevices(),
 		},
 	}
+
+	for _, option := range options {
+		option(provider)
+	}
+
+	return provider
 }
 
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/tailscale/resource_acl_test.go
+++ b/tailscale/resource_acl_test.go
@@ -1,6 +1,7 @@
 package tailscale_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -66,8 +67,12 @@ const testACL = `
 
 func TestProvider_TailscaleACL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testProviderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = nil
+		},
+		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_acl.test_acl", testACL),
 			testResourceDestroyed("tailscale_acl.test_acl", testACL),

--- a/tailscale/resource_device_subnet_routes_test.go
+++ b/tailscale/resource_device_subnet_routes_test.go
@@ -1,8 +1,10 @@
 package tailscale_test
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -12,7 +14,7 @@ const testDeviceSubnetRoutes = `
 	}
 	
 	resource "tailscale_device_subnet_routes" "test_subnet_routes" {
-		device_id = data.tailscale_device.test_device.id,
+		device_id = data.tailscale_device.test_device.id
 		routes = [
 			"10.0.1.0/24", 
 			"1.2.0.0/16", 
@@ -22,8 +24,19 @@ const testDeviceSubnetRoutes = `
 
 func TestProvider_TailscaleDeviceSubnetRoutes(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testProviderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = map[string][]tailscale.Device{
+				"devices": {
+					{
+						Name: "device.example.com",
+						ID:   "123",
+					},
+				},
+			}
+		},
+		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_device_subnet_routes.test_subnet_routes", testDeviceSubnetRoutes),
 			testResourceDestroyed("tailscale_device_subnet_routes.test_subnet_routes", testDeviceSubnetRoutes),

--- a/tailscale/resource_dns_nameservers_test.go
+++ b/tailscale/resource_dns_nameservers_test.go
@@ -1,6 +1,7 @@
 package tailscale_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,8 +17,12 @@ const testNameservers = `
 
 func TestProvider_TailscaleDNSNameservers(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testProviderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = nil
+		},
+		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_nameservers.test_nameservers", testNameservers),
 			testResourceDestroyed("tailscale_dns_nameservers.test_nameservers", testNameservers),

--- a/tailscale/resource_dns_preferences_test.go
+++ b/tailscale/resource_dns_preferences_test.go
@@ -1,6 +1,7 @@
 package tailscale_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,8 +14,12 @@ const testDNSPreferences = `
 
 func TestProvider_TailscaleDNSPreferences(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testProviderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = nil
+		},
+		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_preferences.test_preferences", testDNSPreferences),
 			testResourceDestroyed("tailscale_dns_preferences.test_preferences", testDNSPreferences),

--- a/tailscale/resource_dns_search_paths_test.go
+++ b/tailscale/resource_dns_search_paths_test.go
@@ -1,6 +1,7 @@
 package tailscale_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,8 +16,12 @@ const testSearchPaths = `
 
 func TestProvider_TailscaleDNSSearchPaths(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testProviderPreCheck(t) },
-		ProviderFactories: providerFactories,
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = nil
+		},
+		ProviderFactories: testProviderFactories(t),
 		Steps: []resource.TestStep{
 			testResourceCreated("tailscale_dns_search_paths.test_search_paths", testSearchPaths),
 			testResourceDestroyed("tailscale_dns_search_paths.test_search_paths", testSearchPaths),

--- a/tailscale/tailscale_test.go
+++ b/tailscale/tailscale_test.go
@@ -1,0 +1,70 @@
+package tailscale_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/davidsbond/terraform-provider-tailscale/internal/tailscale"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestServer struct {
+	t *testing.T
+
+	Method string
+	Path   string
+	Body   *bytes.Buffer
+
+	ResponseCode int
+	ResponseBody interface{}
+}
+
+func NewTestHarness(t *testing.T) (*tailscale.Client, *TestServer) {
+	t.Helper()
+
+	testServer := &TestServer{
+		t: t,
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", testServer)
+	svr := &http.Server{
+		Handler: mux,
+	}
+
+	// Start a listener on a random port
+	listener, err := net.Listen("tcp", ":0")
+	assert.NoError(t, err)
+
+	go func() {
+		_ = svr.Serve(listener)
+	}()
+
+	// When the test is over, close the server
+	t.Cleanup(func() {
+		assert.NoError(t, svr.Close())
+	})
+
+	baseURL := fmt.Sprintf("http://localhost:%v", listener.Addr().(*net.TCPAddr).Port)
+	client, err := tailscale.NewClient("", "example.com", tailscale.WithBaseURL(baseURL))
+	assert.NoError(t, err)
+
+	return client, testServer
+}
+
+func (t *TestServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.Method = r.Method
+	t.Path = r.URL.Path
+
+	t.Body = bytes.NewBuffer([]byte{})
+	_, err := io.Copy(t.Body, r.Body)
+	assert.NoError(t.t, err)
+
+	w.WriteHeader(t.ResponseCode)
+	assert.NoError(t.t, json.NewEncoder(w).Encode(t.ResponseBody))
+}


### PR DESCRIPTION
This commit makes some progress on #43, by making the acceptance tests runnable using a mocked
HTTP client. This should at least allow us to catch errors that occur from incorrectly set up
resources/data sources.

It also makes the acceptance tests runnable without requiring a testing environment or the
`TF_ACC` environment variable.

Because these tests currently can take 10s or so to run, I've added caching to the CI.

Signed-off-by: David Bond <davidsbond93@gmail.com>