### PR TITLE
switch resource type for DeviceSubnetRoutes.routes to Set

### DIFF
--- a/tailscale/resource_device_subnet_routes.go
+++ b/tailscale/resource_device_subnet_routes.go
@@ -22,7 +22,7 @@ func resourceDeviceSubnetRoutes() *schema.Resource {
 				Description: "The device to set subnet routes for",
 			},
 			"routes": {
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -52,7 +52,7 @@ func resourceDeviceSubnetRoutesRead(ctx context.Context, d *schema.ResourceData,
 func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*tailscale.Client)
 	deviceID := d.Get("device_id").(string)
-	routes := d.Get("routes").([]interface{})
+	routes := d.Get("routes").(*schema.Set).List()
 
 	subnetRoutes := make([]string, len(routes))
 	for i, route := range routes {
@@ -70,7 +70,7 @@ func resourceDeviceSubnetRoutesCreate(ctx context.Context, d *schema.ResourceDat
 func resourceDeviceSubnetRoutesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*tailscale.Client)
 	deviceID := d.Get("device_id").(string)
-	routes := d.Get("routes").([]interface{})
+	routes := d.Get("routes").(*schema.Set).List()
 
 	subnetRoutes := make([]string, len(routes))
 	for i, route := range routes {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes DeviceSubnetRoutes to have TypeSet instead of TypeList.

TypeList requires the items to be in a specific order; TypeSet does not. Using TypeList can result in unnecessary change detection if output returned by TS API (which does not appear to return in a fully deterministic or sorted order) is in a different order than input. It also makes diffs more difficult to read if e.g. you add a route mid-list and it detects all routes after that as changed.

In my testing, at least, this change appears to migrate cleanly from the previous version with TypeList.

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #57

**Special notes for your reviewer**:
