### PR TITLE
Add tags support to auth keys

### DIFF
--- a/docs/resources/tailnet_key.md
+++ b/docs/resources/tailnet_key.md
@@ -7,7 +7,7 @@ The tailnet_key resource allows you to generate pre-authentication keys for your
 
 # Resource `tailscale_tailnet_key`
 
-The tailnet_key resource allows you to generate pre-authentication keys for your tailnet. See the 
+The `tailnet_key` resource allows you to generate pre-authentication keys for your tailnet. See the
 [Tailscale auth keys](https://tailscale.com/kb/1085/auth-keys/) documentation for more information
 
 ## Example Usage
@@ -21,10 +21,12 @@ resource "tailscale_tailnet_key" "sample_key" {
 
 ## Argument Reference
 
-- `reusable` - (Optional) Determines if the generated key is reusable. Reusable keys can be used to connect multiple 
-nodes. For example, multiple instances of on-prem database might use a reusable key to connect. 
-- `ephemeral` - (Optional) Determines if the generated key is ephemeral. Ephemeral keys are used for authenticating 
+- `reusable` - (Optional) Determines if the generated key is reusable. Reusable keys can be used to connect multiple
+nodes. For example, multiple instances of on-prem database might use a reusable key to connect.
+- `ephemeral` - (Optional) Determines if the generated key is ephemeral. Ephemeral keys are used for authenticating
 ephemeral nodes for short-lived workloads.
+- `tags` - (Optional) Set of tags to apply to the machines authenticated by the key. These tags can be used in ACL
+rules, see the [Tailscale ACL tag documentation](https://tailscale.com/kb/1068/acl-tags/).
 
 ## Attributes Reference
 

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -390,8 +390,9 @@ type (
 	KeyCapabilities struct {
 		Devices struct {
 			Create struct {
-				Reusable  bool `json:"reusable"`
-				Ephemeral bool `json:"ephemeral"`
+				Reusable  bool     `json:"reusable"`
+				Ephemeral bool     `json:"ephemeral"`
+				Tags      []string `json:"tags"`
 			} `json:"create"`
 		} `json:"devices"`
 	}

--- a/tailscale/resource_tailnet_key.go
+++ b/tailscale/resource_tailnet_key.go
@@ -27,6 +27,15 @@ func resourceTailnetKey() *schema.Resource {
 				Description: "Indicates if the key is ephemeral.",
 				ForceNew:    true,
 			},
+			"tags": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of tags to apply to the machines authenticated by the key.",
+				ForceNew:    true,
+			},
 			"key": {
 				Type:        schema.TypeString,
 				Description: "The authentication key",
@@ -46,10 +55,15 @@ func resourceTailnetKeyCreate(ctx context.Context, d *schema.ResourceData, m int
 	client := m.(*tailscale.Client)
 	reusable := d.Get("reusable").(bool)
 	ephemeral := d.Get("ephemeral").(bool)
+	var tags []string
+	for _, tag := range d.Get("tags").(*schema.Set).List() {
+		tags = append(tags, tag.(string))
+	}
 
 	var capabilities tailscale.KeyCapabilities
 	capabilities.Devices.Create.Reusable = reusable
 	capabilities.Devices.Create.Ephemeral = ephemeral
+	capabilities.Devices.Create.Tags = tags
 
 	key, err := client.CreateKey(ctx, capabilities)
 	if err != nil {

--- a/tailscale/resource_tailnet_key_test.go
+++ b/tailscale/resource_tailnet_key_test.go
@@ -12,6 +12,7 @@ const testTailnetKey = `
 	resource "tailscale_tailnet_key" "example_key" {
 		reusable = true
 		ephemeral = true
+		tags = ["tag:server"]
 	}
 `
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It lets users preselect ACL tags to use for the machines authenticated by a key.

See https://tailscale.com/kb/1068/acl-tags/#generate-an-auth-key-with-an-acl-tag