### PR TITLE
Handle disappearing one-off authentication keys

### DIFF
--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -5,6 +5,7 @@ package tailscale
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -437,7 +438,7 @@ func (c *Client) GetKey(ctx context.Context, id string) (Key, error) {
 	return key, c.performRequest(req, &key)
 }
 
-// DeleteKey removes a authentication key from the tailnet.
+// DeleteKey removes an authentication key from the tailnet.
 func (c *Client) DeleteKey(ctx context.Context, id string) error {
 	const uriFmt = "/api/v2/tailnet/%s/keys/%s"
 
@@ -447,4 +448,14 @@ func (c *Client) DeleteKey(ctx context.Context, id string) error {
 	}
 
 	return c.performRequest(req, nil)
+}
+
+// IsNotFound returns true if the provided error implementation is an APIError with a status of 404.
+func IsNotFound(err error) bool {
+	var apiErr APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.status == http.StatusNotFound
+	}
+
+	return false
 }

--- a/internal/tailscale/client_test.go
+++ b/internal/tailscale/client_test.go
@@ -495,3 +495,14 @@ func TestClient_DeleteKey(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, server.Method)
 	assert.Equal(t, "/api/v2/tailnet/example.com/keys/"+keyID, server.Path)
 }
+
+func TestIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusNotFound
+	server.ResponseBody = tailscale.APIError{Message: "error"}
+
+	_, err := client.GetKey(context.Background(), "test")
+	assert.True(t, tailscale.IsNotFound(err))
+}


### PR DESCRIPTION
This commit modifies the `tailnet_key` resource slightly so that one-off keys no longer being present
will not result in errors.

To do this, deletions that result in a 404 error will no longer return an error. Any other errors returned
via the API will still impact it. When reading keys, if a 404 error is returned and the key is not reusable
within the state, it will no longer return an error.

Closes #59

Signed-off-by: David Bond <davidsbond93@gmail.com>
