### PR TITLE
Implement device_tags resource

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -29,3 +29,4 @@ The following attributes are exported.
 - `id` - The unique identifier for the device
 - `user` - The user associated with the device
 - `addresses` - Tailscale IPs for the device
+- `tags` - Tags applied to the device

--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -31,3 +31,4 @@ The following attributes are exported.
   - `name` - The name of the device
   - `user` - The user associated with the device
   - `addresses` - Tailscale IPs for the device
+  - `tags` - Tags applied to the device

--- a/docs/resources/device_tags.md
+++ b/docs/resources/device_tags.md
@@ -1,0 +1,29 @@
+---
+page_title: "device_tags Resource - terraform-provider-tailscale"
+subcategory: ""
+description: |-
+The device_tags resource allows you to apply tags to individual devices within a Tailnet.
+---
+
+# Resource `tailscale_device_tags`
+
+The device_tags resource is used to apply tags to a device within a Tailnet. For more information on ACL tags, see
+the [ACL tags documentation](https://tailscale.com/kb/1068/acl-tags/) for more details.
+
+## Example Usage
+
+```terraform
+data "tailscale_device" "sample_device" {
+  name = "device.example.com"
+}
+
+resource "tailscale_device_tags" "sample_tags" {
+  device_id = data.tailscale_device.sample_device.id,
+  tags = ["room:bedroom"]
+}
+```
+
+## Argument Reference
+
+- `device_id` - (Required) The device to apply tags to.
+- `tags` - (Required) The tags to apply to the device.

--- a/tailscale/data_source_device.go
+++ b/tailscale/data_source_device.go
@@ -31,6 +31,14 @@ func dataSourceDevice() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"tags": {
+				Type:        schema.TypeSet,
+				Description: "The tags applied to the device",
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -67,5 +75,10 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, m interfa
 	if err = d.Set("addresses", selected.Addresses); err != nil {
 		return diagnosticsError(err, "Failed to set addresses")
 	}
+
+	if err = d.Set("tags", selected.Tags); err != nil {
+		return diagnosticsError(err, "Failed to set tags")
+	}
+
 	return nil
 }

--- a/tailscale/data_source_devices.go
+++ b/tailscale/data_source_devices.go
@@ -48,6 +48,14 @@ func dataSourceDevices() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"tags": {
+							Type:        schema.TypeSet,
+							Description: "The tags applied to the device",
+							Computed:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -75,6 +83,7 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, m interf
 			"name":      device.Name,
 			"user":      device.User,
 			"id":        device.ID,
+			"tags":      device.Tags,
 		})
 	}
 

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -39,6 +39,7 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_device_subnet_routes": resourceDeviceSubnetRoutes(),
 			"tailscale_device_authorization": resourceDeviceAuthorization(),
 			"tailscale_tailnet_key":          resourceTailnetKey(),
+			"tailscale_device_tags":          resourceDeviceTags(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"tailscale_device":  dataSourceDevice(),

--- a/tailscale/resource_device_tags.go
+++ b/tailscale/resource_device_tags.go
@@ -1,0 +1,111 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/davidsbond/tailscale-client-go/tailscale"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDeviceTags() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The device_tags resource is used to apply tags to Tailscale devices. See https://tailscale.com/kb/1068/acl-tags/ for more details.",
+		ReadContext:   resourceDeviceTagsRead,
+		CreateContext: resourceDeviceTagsCreate,
+		UpdateContext: resourceDeviceTagsUpdate,
+		DeleteContext: resourceDeviceTagsDelete,
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The device to set tags for",
+			},
+			"tags": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Required:    true,
+				Description: "The tags to apply to the device",
+			},
+		},
+	}
+}
+
+func resourceDeviceTagsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	devices, err := client.Devices(ctx)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch devices")
+	}
+
+	var selected *tailscale.Device
+	for _, device := range devices {
+		if device.ID != deviceID {
+			continue
+		}
+
+		selected = &device
+		break
+	}
+
+	if selected == nil {
+		return diag.Errorf("Could not find device with id %s", deviceID)
+	}
+
+	d.SetId(selected.ID)
+	d.Set("tags", selected.Tags)
+	return nil
+}
+
+func resourceDeviceTagsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+	set := d.Get("tags").(*schema.Set)
+
+	tags := make([]string, set.Len())
+	for i, item := range set.List() {
+		tags[i] = item.(string)
+	}
+
+	if err := client.SetDeviceTags(ctx, deviceID, tags); err != nil {
+		return diagnosticsError(err, "Failed to set device tags")
+	}
+
+	d.SetId(deviceID)
+	return nil
+}
+
+func resourceDeviceTagsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+	set := d.Get("tags").(*schema.Set)
+
+	tags := make([]string, set.Len())
+	for i, item := range set.List() {
+		tags[i] = item.(string)
+	}
+
+	if err := client.SetDeviceTags(ctx, deviceID, tags); err != nil {
+		return diagnosticsError(err, "Failed to set device tags")
+	}
+
+	d.SetId(deviceID)
+	return nil
+}
+
+func resourceDeviceTagsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	if err := client.SetDeviceTags(ctx, deviceID, []string{}); err != nil {
+		return diagnosticsError(err, "Failed to set device tags")
+	}
+
+	d.SetId(deviceID)
+	return nil
+}

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -1,0 +1,44 @@
+package tailscale_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const testDeviceTags = `
+	data "tailscale_device" "test_device" {
+		name = "device.example.com"
+	}
+	
+	resource "tailscale_device_tags" "test_tags" {
+		device_id = data.tailscale_device.test_device.id
+		tags = [
+			"a:b",
+			"b:c",
+		]
+	}`
+
+func TestProvider_TailscaleDeviceTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = map[string][]tailscale.Device{
+				"devices": {
+					{
+						Name: "device.example.com",
+						ID:   "123",
+					},
+				},
+			}
+		},
+		ProviderFactories: testProviderFactories(t),
+		Steps: []resource.TestStep{
+			testResourceCreated("tailscale_device_tags.test_tags", testDeviceTags),
+			testResourceDestroyed("tailscale_device_tags.test_tags", testDeviceTags),
+		},
+	})
+}


### PR DESCRIPTION
This commit introduces the `tailscale_device_tags` resource which allows the user to apply ACL tags
to individual devices. The `tailscale-client-go` package has been updated to 1.1.0 which includes
methods for modifying device tags.

Closes #67

Signed-off-by: David Bond <davidsbond93@gmail.com>