### PR TITLE
Add wait_for argument to tailscale_device data source

### DIFF
--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -14,6 +14,7 @@ The device data source describes a single device in a tailnet.
 ```terraform
 data "tailscale_device" "sample_device" {
   name = "user1-device.example.com"
+  wait_for = "60s"
 }
 
 ```
@@ -21,6 +22,7 @@ data "tailscale_device" "sample_device" {
 ## Argument Reference
 
 - `name` - (Required) The name of the tailnet device to obtain the attributes of.
+- `wait_for` - (Optional) If specified, the provider will retry obtaining the device data every second until the specified duration has been reached. Must be a value greater than 1 second
 
 ## Attributes Reference
 

--- a/tailscale/resource_device_tags_test.go
+++ b/tailscale/resource_device_tags_test.go
@@ -11,6 +11,7 @@ import (
 const testDeviceTags = `
 	data "tailscale_device" "test_device" {
 		name = "device.example.com"
+		wait_for = "60s"
 	}
 	
 	resource "tailscale_device_tags" "test_tags" {


### PR DESCRIPTION
This commit adds a new argument to the `tailscale_device` data source that allows for the configuration
of a retry mechanism. If this argument is provided, the provider will retry obtaining device data every
second up until the maximum duration specified in the `wait_for` argument.

This argument is optional, if it is not specified then the first error will fail the read. The field
is expected to use the string representation of go's `time.Duration` type.

Closes #69 (nice)
