### PR TITLE
Add additional errors to diagnostics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/davidsbond/terraform-provider-tailscale
 go 1.17
 
 require (
-	github.com/davidsbond/tailscale-client-go v1.1.0
+	github.com/davidsbond/tailscale-client-go v1.1.1
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidsbond/tailscale-client-go v1.1.0 h1:0FxhF85jz8FsNU/Z6DMls0LWLjFegbJC6s4JeHxW00w=
-github.com/davidsbond/tailscale-client-go v1.1.0/go.mod h1:aPTr9vEWNLbHDOKdwoZIcQCkUHR57/jIQy/9h8x3v6U=
+github.com/davidsbond/tailscale-client-go v1.1.1 h1:hJfCjEtLuKpdAT6OtDkxV3R0YoAhQQzJaNQWsOPjnUM=
+github.com/davidsbond/tailscale-client-go v1.1.1/go.mod h1:aPTr9vEWNLbHDOKdwoZIcQCkUHR57/jIQy/9h8x3v6U=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/davidsbond/tailscale-client-go/tailscale/client.go
+++ b/vendor/github.com/davidsbond/tailscale-client-go/tailscale/client.go
@@ -25,8 +25,15 @@ type (
 
 	// The APIError type describes an error as returned by the Tailscale API.
 	APIError struct {
-		Message string `json:"message"`
+		Message string         `json:"message"`
+		Data    []APIErrorData `json:"data"`
 		status  int
+	}
+
+	// The APIErrorData type describes elements of the data field within errors returned by the Tailscale API.
+	APIErrorData struct {
+		User   string   `json:"user"`
+		Errors []string `json:"errors"`
 	}
 
 	// The ClientOption type is a function that is used to modify a Client.
@@ -484,4 +491,15 @@ func IsNotFound(err error) bool {
 	}
 
 	return false
+}
+
+// ErrorData returns the contents of the APIError.Data field from the provided error if it is of type APIError. Returns
+// a nil slice if the given error is not of type APIError.
+func ErrorData(err error) []APIErrorData {
+	var apiErr APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Data
+	}
+
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/apparentlymart/go-textseg/v13/textseg
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/davidsbond/tailscale-client-go v1.1.0
+# github.com/davidsbond/tailscale-client-go v1.1.1
 ## explicit; go 1.17
 github.com/davidsbond/tailscale-client-go/tailscale
 # github.com/fatih/color v1.13.0


### PR DESCRIPTION
Closes #73

This commit adds additional error details when an error response from the API contains entries in its `Data` field. These
errors are typically returned from failing ACL tests. Each error is given its own diagnostic describing the user and the
error.

Signed-off-by: David Bond <davidsbond93@gmail.com>