### PR TITLE
Add tailscale_device_key resource

### DIFF
--- a/docs/resources/device_key.md
+++ b/docs/resources/device_key.md
@@ -1,0 +1,31 @@
+---
+page_title: "device_key Resource - terraform-provider-tailscale"
+subcategory: ""
+description: |-
+The device_key resource allows you to generate pre-authentication keys for your device.
+---
+
+# Resource `tailscale_device_key`
+
+The `device_key` resource allows you to modify the property of a device's key.
+
+## Example Usage
+
+```terraform
+data "tailscale_device" "example_device" {
+  name = "device.example.com"
+}
+
+resource "tailscale_device_key" "example_key" {
+  device_id = data.tailscale_device.example_device.id
+  preauthorized = true
+  key_expiry_disabled = true
+}
+```
+
+## Argument Reference
+
+- `device_id` - (Required) The device to change the key properties of.
+- `preauthorized` - (Optional) Whether the device should be authorized for the tailnet by default, works in tailnets 
+where device authorization is enabled.
+- `key_expiry_disabled` - (Optional) Whether the device's key will ever expire.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/davidsbond/terraform-provider-tailscale
 go 1.17
 
 require (
-	github.com/davidsbond/tailscale-client-go v1.2.0
+	github.com/davidsbond/tailscale-client-go v1.2.1
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidsbond/tailscale-client-go v1.2.0 h1:ArTPq2uBG7kCZD6oTkA3rxrKgocqgizbUjBTqZjC59U=
-github.com/davidsbond/tailscale-client-go v1.2.0/go.mod h1:aPTr9vEWNLbHDOKdwoZIcQCkUHR57/jIQy/9h8x3v6U=
+github.com/davidsbond/tailscale-client-go v1.2.1 h1:yiDnJrdK5Sa3Z33H3EmA+mx9jGp3LL0e2HmVfOyXG0o=
+github.com/davidsbond/tailscale-client-go v1.2.1/go.mod h1:aPTr9vEWNLbHDOKdwoZIcQCkUHR57/jIQy/9h8x3v6U=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -41,6 +41,7 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"tailscale_device_authorization": resourceDeviceAuthorization(),
 			"tailscale_tailnet_key":          resourceTailnetKey(),
 			"tailscale_device_tags":          resourceDeviceTags(),
+			"tailscale_device_key":           resourceDeviceKey(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"tailscale_device":  dataSourceDevice(),

--- a/tailscale/resource_device_key.go
+++ b/tailscale/resource_device_key.go
@@ -1,0 +1,122 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDeviceKey() *schema.Resource {
+	return &schema.Resource{
+		Description:   "The device_key resource allows you to update the properties of a device's key",
+		ReadContext:   resourceDeviceKeyRead,
+		CreateContext: resourceDeviceKeyCreate,
+		DeleteContext: resourceDeviceKeyDelete,
+		UpdateContext: resourceDeviceKeyUpdate,
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The device to update the key properties of",
+			},
+			"key_expiry_disabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines whether or not the device's key will expire",
+			},
+			"preauthorized": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines whether or not the device will be authorized for the tailnet by default.",
+			},
+		},
+	}
+}
+
+func resourceDeviceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+
+	deviceID := d.Get("device_id").(string)
+	preauthorized := d.Get("preauthorized").(bool)
+	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)
+
+	key := tailscale.DeviceKey{
+		KeyExpiryDisabled: keyExpiryDisabled,
+		Preauthorized:     preauthorized,
+	}
+
+	if err := client.SetDeviceKey(ctx, deviceID, key); err != nil {
+		return diagnosticsError(err, "failed to update device key")
+	}
+
+	d.SetId(deviceID)
+	return nil
+}
+
+func resourceDeviceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+
+	deviceID := d.Get("device_id").(string)
+	key := tailscale.DeviceKey{}
+
+	if err := client.SetDeviceKey(ctx, deviceID, key); err != nil {
+		return diagnosticsError(err, "failed to update device key")
+	}
+
+	return nil
+}
+
+func resourceDeviceKeyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+	deviceID := d.Get("device_id").(string)
+
+	devices, err := client.Devices(ctx)
+	if err != nil {
+		return diagnosticsError(err, "Failed to fetch devices")
+	}
+
+	var selected *tailscale.Device
+	for _, device := range devices {
+		if device.ID != deviceID {
+			continue
+		}
+
+		selected = &device
+		break
+	}
+
+	if selected == nil {
+		return diag.Errorf("Could not find device with id %s", deviceID)
+	}
+
+	if err = d.Set("preauthorized", selected.Authorized); err != nil {
+		return diagnosticsError(err, "failed to set authorized field")
+	}
+
+	if err = d.Set("key_expiry_disabled", selected.KeyExpiryDisabled); err != nil {
+		return diagnosticsError(err, "failed to set key_expiry_disabled field")
+	}
+
+	return nil
+}
+
+func resourceDeviceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*tailscale.Client)
+
+	deviceID := d.Get("device_id").(string)
+	preauthorized := d.Get("preauthorized").(bool)
+	keyExpiryDisabled := d.Get("key_expiry_disabled").(bool)
+
+	key := tailscale.DeviceKey{
+		KeyExpiryDisabled: keyExpiryDisabled,
+		Preauthorized:     preauthorized,
+	}
+
+	if err := client.SetDeviceKey(ctx, deviceID, key); err != nil {
+		return diagnosticsError(err, "failed to update device key")
+	}
+
+	return nil
+}

--- a/tailscale/resource_device_key_test.go
+++ b/tailscale/resource_device_key_test.go
@@ -1,0 +1,42 @@
+package tailscale_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/davidsbond/tailscale-client-go/tailscale"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const testDeviceKey = `
+	data "tailscale_device" "test_device" {
+		name = "device.example.com"
+	}
+	
+	resource "tailscale_device_key" "test_key" {
+		device_id = data.tailscale_device.test_device.id
+		preauthorized = true
+		key_expiry_disabled = true
+	}`
+
+func TestProvider_TailscaleDeviceKey(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		PreCheck: func() {
+			testServer.ResponseCode = http.StatusOK
+			testServer.ResponseBody = map[string][]tailscale.Device{
+				"devices": {
+					{
+						Name: "device.example.com",
+						ID:   "123",
+					},
+				},
+			}
+		},
+		ProviderFactories: testProviderFactories(t),
+		Steps: []resource.TestStep{
+			testResourceCreated("tailscale_device_key.test_key", testDeviceKey),
+			testResourceDestroyed("tailscale_device_key.test_key", testDeviceKey),
+		},
+	})
+}

--- a/vendor/github.com/davidsbond/tailscale-client-go/tailscale/client.go
+++ b/vendor/github.com/davidsbond/tailscale-client-go/tailscale/client.go
@@ -355,12 +355,13 @@ func (c *Client) DeviceSubnetRoutes(ctx context.Context, deviceID string) (*Devi
 }
 
 type Device struct {
-	Addresses  []string `json:"addresses"`
-	Name       string   `json:"name"`
-	ID         string   `json:"id"`
-	Authorized bool     `json:"authorized"`
-	User       string   `json:"user"`
-	Tags       []string `json:"tags"`
+	Addresses         []string `json:"addresses"`
+	Name              string   `json:"name"`
+	ID                string   `json:"id"`
+	Authorized        bool     `json:"authorized"`
+	User              string   `json:"user"`
+	Tags              []string `json:"tags"`
+	KeyExpiryDisabled bool     `json:"keyExpiryDisabled"`
 }
 
 // Devices lists the devices in a tailnet.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/apparentlymart/go-textseg/v13/textseg
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/davidsbond/tailscale-client-go v1.2.0
+# github.com/davidsbond/tailscale-client-go v1.2.1
 ## explicit; go 1.17
 github.com/davidsbond/tailscale-client-go/tailscale
 # github.com/fatih/color v1.13.0


### PR DESCRIPTION
Closes #78

This commit introduces the `tailscale_device_key` resource which is used to modify the properties of the device's key.

Currently, this resource can disable device key expiry and pre-authorize a device for the tailnet. The read operation
checks the value of the device's `authorized` and `keyExpiryDisabled` fields, as there's no way to read the key properties
directly.

Signed-off-by: David Bond <davidsbond93@gmail.com>
