### PR TITLE
Add error data to summary field instead of detail field

### DIFF
--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -87,7 +87,7 @@ func diagnosticsError(err error, message string, args ...interface{}) diag.Diagn
 			for _, e := range dt.Errors {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
-					Detail:   fmt.Sprintf("user: %s\nerror: %s", dt.User, e),
+					Summary:  fmt.Sprintf("user: %s\nerror: %s", dt.User, e),
 				})
 			}
 		}


### PR DESCRIPTION
Closes #91

Terraform will crash when adding errors that do not include the summary field. This
commit adds extra error data to the summary field instead of the detail field.

Signed-off-by: David Bond <davidsbond93@gmail.com>
