### PR TITLE
Allow declaration of tailscale api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ provider "tailscale" {
 In the `provider` block, replace `api_key` and `tailnet` with your own tailnet and API key. Alternatively, use the
 `TAILSCALE_API_KEY` and `TAILSCALE_TAILNET` environment variables.
 
+The default api endpoint is `https://api.tailscale.com`. If your coordination/control server api is at another endpoint, you can pass in `base_url` in the provider block.
+
+```terraform
+provider "tailscale" {
+  api_key = "my_api_key"
+  tailnet = "example.com"
+  base_url = "https://api.us.tailscale.com"
+}
+```
+
 ## Contributing
 
 Please review the [contributing guidelines](./CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md) before

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,15 @@ provider "tailscale" {
 }
 ```
 
+**Optional**
+```terraform
+provider "tailscale" {
+  api_key = "my_api_key"
+  tailnet = "example.com"
+  base_url = "https://api.us.tailscale.com"
+}
+```
+
 ## Schema
 
 ### Required
@@ -31,3 +40,7 @@ provider "tailscale" {
 A tailnet is the name of your Tailscale network. You can find it in the top left corner of the Admin Panel beside the 
 Tailscale logo. `alice@example.com` belongs to the `example.com` tailnet. For solo plans, the tailnet is the email you 
 signed up with. So `alice@gmail.com` has the tailnet `alice@gmail.com` since `@gmail.com` is a shared email host.
+
+### Optional
+
+- **base_url** (String - `TAILSCALE_BASE_URL`) Tailscale API endpoint URL. Default is `https://api.tailscale.com`.

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -34,7 +34,7 @@ func Provider(options ...ProviderOption) *schema.Provider {
 			"base_url": {
 				Type:        schema.TypeString,
 				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_BASE_URL", "https://api.tailscale.com"),
-				Required:    true,
+				Optional:    true,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -31,9 +31,9 @@ func Provider(options ...ProviderOption) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_TAILNET", nil),
 				Required:    true,
 			},
-			"baseurl": {
+			"base_url": {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_BASEURL", nil),
+				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_BASE_URL", "https://api.tailscale.com"),
 				Required:    true,
 			},
 		},
@@ -64,9 +64,9 @@ func Provider(options ...ProviderOption) *schema.Provider {
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	apiKey := d.Get("api_key").(string)
 	tailnet := d.Get("tailnet").(string)
-	baseurl := d.Get("baseurl").(string)
-	newbase := tailscale.WithBaseURL(baseurl)
-	client, err := tailscale.NewClient(apiKey, tailnet, newbase)
+	baseURL := d.Get("base_url").(string)
+
+	client, err := tailscale.NewClient(apiKey, tailnet, tailscale.WithBaseURL(baseURL))
 	if err != nil {
 		return nil, diagnosticsError(err, "failed to initialise client")
 	}

--- a/tailscale/provider.go
+++ b/tailscale/provider.go
@@ -31,6 +31,11 @@ func Provider(options ...ProviderOption) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_TAILNET", nil),
 				Required:    true,
 			},
+			"baseurl": {
+				Type:        schema.TypeString,
+				DefaultFunc: schema.EnvDefaultFunc("TAILSCALE_BASEURL", nil),
+				Required:    true,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"tailscale_acl":                  resourceACL(),
@@ -59,8 +64,9 @@ func Provider(options ...ProviderOption) *schema.Provider {
 func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	apiKey := d.Get("api_key").(string)
 	tailnet := d.Get("tailnet").(string)
-
-	client, err := tailscale.NewClient(apiKey, tailnet)
+	baseurl := d.Get("baseurl").(string)
+	newbase := tailscale.WithBaseURL(baseurl)
+	client, err := tailscale.NewClient(apiKey, tailnet, newbase)
 	if err != nil {
 		return nil, diagnosticsError(err, "failed to initialise client")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to declare the baseurl in the provider block. Add a new baseurl variable.

**Which issue this PR fixes** *(use `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes https://github.com/davidsbond/terraform-provider-tailscale/issues/97

**Special notes for your reviewer**:
